### PR TITLE
Internationalization of scientific fields

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -16,10 +16,11 @@ class AccountController < ApplicationController
     @action_title = "#{I18n.t "controllers.account.update_personal_details"}"
     if params[:locale] == "el"
       @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
+      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_el, 40), o.id]}
     else
       @organizations = Organization.find(:all,:order => "name_en ASC").map {|o| [truncate(o.name_en, 40) || truncate(o.name_el, 40), o.id]}
+      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_en, 40), o.id]}
     end
-    @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description, 40), o.id]}
     @person = Person.find_by_dn(session[:usercert])
   end
   
@@ -48,10 +49,11 @@ class AccountController < ApplicationController
     else
      if params[:locale] == "el"
       @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
+      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_el, 40), o.id]}
     else
       @organizations = Organization.find(:all,:order => "name_en ASC").map {|o| [truncate(o.name_en, 40) || truncate(o.name_el, 40), o.id]}
+      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_en, 40), o.id]}
     end
-      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description, 40), o.id]}
       render :action => "edit_personal_information"
     end
   end

--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -14,13 +14,8 @@ class AccountController < ApplicationController
   
   def edit_personal_information
     @action_title = "#{I18n.t "controllers.account.update_personal_details"}"
-    if params[:locale] == "el"
-      @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
-      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_el, 40), o.id]}
-    else
-      @organizations = Organization.find(:all,:order => "name_en ASC").map {|o| [truncate(o.name_en, 40) || truncate(o.name_el, 40), o.id]}
-      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_en, 40), o.id]}
-    end
+    @organizations = Organization.find(:all,:order => "name_#{params[:locale]} ASC").map {|o| [truncate(o.send("name_#{params[:locale]}"), 40), o.id]}
+    @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.send("description_#{params[:locale]}"), 40), o.id]}
     @person = Person.find_by_dn(session[:usercert])
   end
   
@@ -47,13 +42,8 @@ class AccountController < ApplicationController
       # render (:text => "<pre>" + email.encoded + "</pre>")
       # redirect_to :action => "csr_form"
     else
-     if params[:locale] == "el"
-      @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
-      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_el, 40), o.id]}
-    else
-      @organizations = Organization.find(:all,:order => "name_en ASC").map {|o| [truncate(o.name_en, 40) || truncate(o.name_el, 40), o.id]}
-      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_en, 40), o.id]}
-    end
+      @organizations = Organization.find(:all,:order => "name_#{params[:locale]} ASC").map {|o| [truncate(o.send("name_#{params[:locale]}"), 40), o.id]}
+      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.send("description_#{params[:locale]}"), 40), o.id]}
       render :action => "edit_personal_information"
     end
   end

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -19,10 +19,11 @@ class RegisterController < ApplicationController
     @action_title = "#{I18n.t "controllers.register.user_registration_form"}"
     if params[:locale] == "el"
       @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
+      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_el, 40), o.id]}
     else
       @organizations = Organization.find(:all,:order => "name_en ASC").map {|o| [truncate(o.name_en, 40) || truncate(o.name_el, 40), o.id]}
+      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_en, 40), o.id]}
     end
-    @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description, 40), o.id]}
   end
   
   # Pros8etei enan kainourgio xrhsth sthn database. An uparxei
@@ -57,11 +58,12 @@ class RegisterController < ApplicationController
       # redirect_to :action => "csr_form"
     else
       if params[:locale] == "el"
-      @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
+        @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
+        @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_el, 40), o.id]}
       else
         @organizations = Organization.find(:all,:order => "name_en ASC").map {|o| [truncate(o.name_en, 40) || truncate(o.name_el, 40), o.id]}
+        @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_en, 40), o.id]}
       end
-      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description, 40), o.id]}
       render :action => "registration_form"
     end
   end

--- a/app/controllers/register_controller.rb
+++ b/app/controllers/register_controller.rb
@@ -17,13 +17,8 @@ class RegisterController < ApplicationController
   # gia na doulepsei h truncate
   def registration_form
     @action_title = "#{I18n.t "controllers.register.user_registration_form"}"
-    if params[:locale] == "el"
-      @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
-      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_el, 40), o.id]}
-    else
-      @organizations = Organization.find(:all,:order => "name_en ASC").map {|o| [truncate(o.name_en, 40) || truncate(o.name_el, 40), o.id]}
-      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_en, 40), o.id]}
-    end
+    @organizations = Organization.find(:all,:order => "name_#{params[:locale]} ASC").map {|o| [truncate(o.send("name_#{params[:locale]}"), 40), o.id]}
+    @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.send("description_#{params[:locale]}"), 40), o.id]}
   end
   
   # Pros8etei enan kainourgio xrhsth sthn database. An uparxei
@@ -57,13 +52,8 @@ class RegisterController < ApplicationController
       # render(:text => "<pre>" + email.encoded + "</pre>")
       # redirect_to :action => "csr_form"
     else
-      if params[:locale] == "el"
-        @organizations = Organization.find(:all,:order => "name_el ASC").map {|o| [truncate(o.name_el, 40), o.id]}
-        @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_el, 40), o.id]}
-      else
-        @organizations = Organization.find(:all,:order => "name_en ASC").map {|o| [truncate(o.name_en, 40) || truncate(o.name_el, 40), o.id]}
-        @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.description_en, 40), o.id]}
-      end
+      @organizations = Organization.find(:all,:order => "name_#{params[:locale]} ASC").map {|o| [truncate(o.send("name_#{params[:locale]}"), 40), o.id]}
+      @scientific_fields = ScientificField.find(:all).map {|o| [truncate(o.send("description_#{params[:locale]}"), 40), o.id]}
       render :action => "registration_form"
     end
   end

--- a/db/migrate/20150720182254_add_english_name_for_scientific_fields.rb
+++ b/db/migrate/20150720182254_add_english_name_for_scientific_fields.rb
@@ -1,0 +1,40 @@
+class AddEnglishNameForScientificFields < ActiveRecord::Migration
+  def self.up
+  	add_column :scientific_fields, :description_en, :string
+  	rename_column :scientific_fields, :description, :description_el
+  	ScientificField.find_each do |sf|
+  		case sf.description_el
+  		when "Άλλο"
+  			sf.description_en = "Other"
+		when "Αστροφυσική και σωματιδιακή αστροφυσική"
+			sf.description_en = "Astrophysics and particle astrophysics"
+		when "Εφαρμογές βιοϊατρικής και βιοπληροφορικής"
+			sf.description_en = "Applied biomedicine and bioinformatics"
+		when "Υπολογιστική Χημεία"
+			sf.description_en = "Computational cshemistry"
+		when "Γεωπιστήμες"
+			sf.description_en = "Geoscience"
+		when "Οικονομία"
+			sf.description_en = "Economics"
+		when "Σύντηξη"
+			sf.description_en = "Fusion"
+		when "Γεωφυσική"
+			sf.description_en = "Geophysics"
+		when "Φυσική υψηλών ενεργειών"
+			sf.description_en = "High energy physics"
+		when "Μηχανική"
+			sf.description_en = "Mechanics"
+		when "Επιστήμη υπολογιστών"
+			sf.description_en = "Computer science"
+		when "Μαθηματικών"
+			sf.description_en = "Mathematics"
+  		end
+  	sf.save!
+  	end
+  end
+
+  def self.down
+  	rename_column :scientific_fields, :description_el, :description
+  	remove_column :scientific_fields, :description_en
+  end
+end


### PR DESCRIPTION
Proposed solution for **issue #9**.

In essence, it inserts a new column in the **scientific_fields** table of the database (*description_en*) and renames the generic *description* column to *description_el*.

The rest of the changes related to the changed name and the showing of the correct language of the scientific fields according to the locale selected.