### PR TITLE
Fix build status icon in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Access CA Portal [![Build Status](https://jenkins.admin.grnet.gr/job/access-ca-portal_devel/badge/icon)](https://jenkins.admin.grnet.gr/job/access-ca-portal_devel)
+# Access CA Portal [![Build Status](http://jenkins.admin.grnet.gr/job/access-ca-portal_devel/badge/icon)](https://jenkins.admin.grnet.gr/job/access-ca-portal_devel)
 
 ## Overview
 


### PR DESCRIPTION
This PR is a temporary workaround for actually showing the build status icon in README (refs #21). It seems GitHub's image caching service for its markdown pages does not handle the HTTPS URL to the Jenkins instance properly, probably due to the self-signed certificate currently in use. We will thus use plain HTTP for now but we must move back to HTTPS once we get a proper CA-signed SSL certificate.

/cc @stevelaskaridis @arossiko 
