### PR TITLE
ci/cobertura

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Access CA Portal [![Build Status](https://jenkins.argo.grnet.gr/job/access-ca-portal_devel/badge/icon)](https://jenkins.argo.grnet.gr/job/access-ca-portal_devel)
+# Access CA Portal [![Build Status](https://jenkins.argo.grnet.gr/job/access-ca-portal_devel/badge/icon)](https://jenkins.argo.grnet.gr/job/access-ca-portal_devel) [![Test Coverage](http://jenkins.argo.grnet.gr:9913/jenkins/c/http/jenkins.argo.grnet.gr/job/access-ca-portal_devel)](https://jenkins.argo.grnet.gr/job/access-ca-portal_devel/cobertura)
 
 ## Overview
 

--- a/access/Gemfile
+++ b/access/Gemfile
@@ -62,4 +62,4 @@ group :development do
 end
 
 gem 'simplecov', :require => false, :group => :test
-gem 'simplecov-rcov', :require => false, :group => :test
+gem 'simplecov-cobertura', :require => false, :group => :test

--- a/access/Gemfile.lock
+++ b/access/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    libxml-ruby (2.8.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -145,9 +146,10 @@ GEM
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
+    simplecov-cobertura (1.0.2)
+      libxml-ruby (~> 2.7)
+      simplecov (~> 0.8)
     simplecov-html (0.10.0)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     spring (1.4.0)
     sprockets (3.4.0)
       rack (> 1, < 3)
@@ -190,7 +192,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simplecov
-  simplecov-rcov
+  simplecov-cobertura
   spring
   sqlite3
   turbolinks

--- a/access/test/test_helper.rb
+++ b/access/test/test_helper.rb
@@ -1,7 +1,9 @@
 ENV['RAILS_ENV'] ||= 'test'
 require 'simplecov'
-require 'simplecov-rcov'
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+require 'simplecov-cobertura'
+SimpleCov.formatters = [
+  SimpleCov::Formatter::CoberturaFormatter,
+]
 SimpleCov.start
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -9,6 +9,7 @@ RUN             yum -y install \
                   git \
                   tar \
                   postgresql-devel \
+                  libxml2-devel \
                   epel-release
 RUN             yum clean all
 RUN             yum -y install \


### PR DESCRIPTION
This PR adds a test coverage badge to the main README. To support this, test coverage reporting needs to be migrated from using simplecov-rcov to [simplecov-cobertura](https://github.com/dashingrocket/simplecov-cobertura).
