### PR TITLE
Add rake task for generating XML test reports (Closes #109)

### DIFF
--- a/access/Gemfile
+++ b/access/Gemfile
@@ -63,3 +63,5 @@ end
 
 gem 'simplecov', :require => false, :group => :test
 gem 'simplecov-cobertura', :require => false, :group => :test
+gem 'ci_reporter', :require => false, :group => :test
+gem 'ci_reporter_minitest', :require => false, :group => :test

--- a/access/Gemfile.lock
+++ b/access/Gemfile.lock
@@ -60,6 +60,11 @@ GEM
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (6.0.2)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_minitest (1.0.0)
+      ci_reporter (~> 2.0)
+      minitest (~> 5.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -180,6 +185,8 @@ PLATFORMS
 DEPENDENCIES
   byebug
   certificate_authority!
+  ci_reporter
+  ci_reporter_minitest
   coffee-rails (~> 4.1.0)
   globalize (~> 5.0.0)
   globalize-versioning!

--- a/access/Rakefile
+++ b/access/Rakefile
@@ -4,3 +4,8 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+
+if ENV['GENERATE_REPORTS'] == 'true'
+  require 'ci/reporter/rake/minitest'
+  task :ci_report => 'ci:setup:minitest'
+end


### PR DESCRIPTION
This PR adds support for generating XML test reports that can be published through Jenkins. A summary of the tests can also be included in the GitHub commit status set by Jenkins.

Reporting is controlled through the `GENERATE_REPORTS` environment variable (see Rakefile) as follows:

```
GENERATE_REPORTS=true rake ci_report test test/models/*test.rb
```

Required Gems:
- [CI::Reporter](https://github.com/ci-reporter/ci_reporter)
- [CI::Reporter::Minitest](https://github.com/ci-reporter/ci_reporter_minitest)
