### PR TITLE
Modify schema.rb to fix 'Local modifications' ansible error

### DIFF
--- a/access/db/schema.rb
+++ b/access/db/schema.rb
@@ -12,6 +12,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20151201222250) do
+
   create_table "alternative_emails", force: :cascade do |t|
     t.integer  "person_id",                          null: false
     t.string   "email",                              null: false


### PR DESCRIPTION
This PR aims to fix the `"msg: Local modifications exist in repository (force=no)."` error when re-running `access.yml` playbook. The modification is actually a newline introduced in the `schema.rb` file once the `rake db:migrate` task is executed.
