### PR TITLE
Logged in singup fix.

### DIFF
--- a/access/app/controllers/people_controller.rb
+++ b/access/app/controllers/people_controller.rb
@@ -1,6 +1,7 @@
 class PeopleController < ApplicationController
   before_action :set_person, only: [:show, :edit, :update, :destroy]
   before_filter :authorize!, except: [:create, :new]
+  before_filter :check_singed_in, only: [:create, :new]
   # GET /people
   # GET /people.json
   def index
@@ -151,6 +152,12 @@ class PeopleController < ApplicationController
       super
       if @person && (@person != current_user) && (!TmpAdmin.is_admin?(current_user))
         redirect_to people_url, alert: "#{I18n.t 'controllers.authorization.not_authorized'}"
+      end
+    end
+
+    def check_singed_in
+      if current_user
+        redirect_to current_user, notice: "#{I18n.t 'controllers.session.already_logged_in'}"
       end
     end
 end

--- a/access/app/views/site/index.html.erb
+++ b/access/app/views/site/index.html.erb
@@ -4,11 +4,12 @@
 
 <h3> <%= "#{I18n.t "views.homepage.account_related"}" %></h3>
 <ul>
-  <li><%= link_to "#{I18n.t "views.homepage.create_account"}", signup_url %></li>
   <% if current_user %>
       <li><%= link_to "#{I18n.t "views.homepage.account_details"}", current_user %></li>
       <li><%= link_to "#{I18n.t "views.homepage.delete_account"}", current_user, method: :delete, data: {confirm: I18n.t("views.delete_confirmation")} %></li>
       <li><%= link_to "#{I18n.t "views.homepage.account_changes"}", "/people/#{current_user.id}/versions" %></li>
+  <%else%>
+      <li><%= link_to "#{I18n.t "views.homepage.create_account"}", signup_url %></li>
   <% end %>
 
 </ul>

--- a/access/config/locales/controllers/el.yml
+++ b/access/config/locales/controllers/el.yml
@@ -6,3 +6,4 @@ el:
     session:
       welcome: "Καλώς ορίσατε!"
       invalid_email: "Το παρόν e-mail δε βρέθηκε."
+      already_logged_in: "Ήδη συνδεδεμένος."

--- a/access/config/locales/controllers/en.yml
+++ b/access/config/locales/controllers/en.yml
@@ -6,3 +6,4 @@ en:
     session:
       welcome: "Welcome!"
       invalid_email: "The current e-mail could not be found."
+      already_logged_in: "Already logged in."


### PR DESCRIPTION
## Description

When a user is logged in, they cannot sign up again.
- Option not shown in main page
- URL of signup redirects to person details with relevant notice.
## Github issues

Addresses issue #112.
